### PR TITLE
Handle message payload when it's a string

### DIFF
--- a/mbox_tools/__init__.py
+++ b/mbox_tools/__init__.py
@@ -58,7 +58,7 @@ def generate_csv_digest(source_file, output_file):
         fmt_message['body'] = ' --- MESSAGE PAYLOAD PART BOUNDARY --- '.join([
             item.get_payload() for item in message.get_payload()
             if item.get_content_type() == 'text/plain'
-        ])
+        ]) if message.is_multipart() else message.get_payload().strip()
 
         fmt_message['attachments'] = '  //  '.join([
             item['Content-Disposition'].split('filename=')[1].strip('"')
@@ -67,7 +67,7 @@ def generate_csv_digest(source_file, output_file):
                 'text/plain',
                 'message/rfc822',
             ]
-        ])
+        ]) if message.is_multipart() else ''
 
         formatted_messages.append(fmt_message)
 


### PR DESCRIPTION
`get_payload` will be a string if not multipart.

```
Traceback (most recent call last):
  File "mbox.py", line 4, in <module>
    generate_csv_digest('…/source_file.mbox', '…/output_file.csv')
  File "…/.venv/lib/python3.7/site-packages/mbox_tools/__init__.py", line 59, in generate_csv_digest
    item.get_payload() for item in message.get_payload()
  File "…/.venv/lib/python3.7/site-packages/mbox_tools/__init__.py", line 60, in <listcomp>
    if item.get_content_type() == 'text/plain'
AttributeError: 'str' object has no attribute 'get_content_type'
```

- https://docs.python.org/3/library/email.compat32-message.html#email.message.Message.get_payload
- https://docs.python.org/2/library/email.message.html#email.message.Message.get_payload

FWIW, looks like the Python 3 API for email messages is quite a bit different.

- https://docs.python.org/3/library/email.message.html